### PR TITLE
10D, 30D, D20, D80 Support + D20 array processing preset selection + minor fixes

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -12,7 +12,7 @@ export function updateA(self) {
 					choices: [
 						{ id: 1, label: 'On' },
 						{ id: 0, label: 'Off' },
-						{ id: -1, label: 'Toggel' },
+						{ id: -1, label: 'Toggle' },
 					],
 					default: 0,
 				},
@@ -162,10 +162,10 @@ export function updateA(self) {
 			},
 		},
 		toggelmute_action: {
-			name: 'Toggel Amp Channel',
+			name: 'Toggle Amp Channel',
 			options: [
 				{
-					id: 'toggelmute',
+					id: 'togglemute',
 					type: 'dropdown',
 					label: 'Channel',
 					choices: [
@@ -180,7 +180,7 @@ export function updateA(self) {
 			],
 			callback: async (event) => {
 				if (self.ready) {
-					if (event.options.toggelmute === -1) {
+					if (event.options.togglemute === -1) {
 						self.muteObj.forEach((obj, index) => {
 							obj
 								.GetState()
@@ -210,23 +210,23 @@ export function updateA(self) {
 								})
 						})
 					} else {
-						self.muteObj[event.options.toggelmute]
+						self.muteObj[event.options.togglemute]
 							.GetState()
 							.then((v) => {
 								if (v === Types.OcaMuteState.Muted) {
-									self.muteObj[event.options.toggelmute]
+									self.muteObj[event.options.togglemute]
 										.SetState(Types.OcaMuteState.Unmuted)
 										.then(() => {
-											self.log('info', 'Unmute Ch: ' + numberToChar(event.options.toggelmute))
+											self.log('info', 'Unmute Ch: ' + numberToChar(event.options.togglemute))
 										})
 										.catch((err) => {
 											self.log('error', err.toString())
 										})
 								} else {
-									self.muteObj[event.options.toggelmute]
+									self.muteObj[event.options.togglemute]
 										.SetState(Types.OcaMuteState.Muted)
 										.then(() => {
-											self.log('info', 'Mute Ch: ' + numberToChar(event.options.toggelmute))
+											self.log('info', 'Mute Ch: ' + numberToChar(event.options.togglemute))
 										})
 										.catch((err) => {
 											self.log('error', err.toString())

--- a/actions.js
+++ b/actions.js
@@ -14,7 +14,7 @@ export function updateA(self) {
 						{ id: 0, label: 'Off' },
 						{ id: -1, label: 'Toggle' },
 					],
-					default: 0,
+					default: -1,
 				},
 			],
 			callback: async (event) => {
@@ -89,7 +89,7 @@ export function updateA(self) {
 						{ id: 3, label: 'D' },
 						{ id: -1, label: 'All' },
 					],
-					default: 0,
+					default: -1,
 				},
 			],
 			callback: async (event) => {
@@ -132,7 +132,7 @@ export function updateA(self) {
 						{ id: 3, label: 'D' },
 						{ id: -1, label: 'All' },
 					],
-					default: 0,
+					default: -1,
 				},
 			],
 			callback: async (event) => {
@@ -175,7 +175,7 @@ export function updateA(self) {
 						{ id: 3, label: 'D' },
 						{ id: -1, label: 'All' },
 					],
-					default: 0,
+					default: -1,
 				},
 			],
 			callback: async (event) => {

--- a/actions.js
+++ b/actions.js
@@ -1,4 +1,4 @@
-import { Types } from 'aes70'
+import { Types, RemoteControlClasses } from 'aes70';
 
 export function updateA(self) {
 	self.setActionDefinitions({
@@ -238,6 +238,66 @@ export function updateA(self) {
 							})
 					}
 				}
+			},
+		},
+		loadAPpreset_action: {
+			name: 'Load Array Processing Preset (D20)',
+			options: [
+				{
+					id: 'APspeaker',
+					type: 'dropdown',
+					label: 'Speaker',
+					choices: [
+						{ id: 0, label: 'A' },
+						{ id: 1, label: 'B' },
+						{ id: 2, label: 'C' },
+						{ id: 3, label: 'D' },
+						{ id: -1, label: 'All' },
+					],
+					default: -1,
+				},
+				{
+					id: 'APpreset',
+					type: 'dropdown',
+					label: 'Preset Number',
+					choices: [
+						{ id: 0, label: '1 (bypass)' },
+						{ id: 1, label: '2' },
+						{ id: 2, label: '3' },
+						{ id: 3, label: '4' },
+						{ id: 4, label: '5' },
+						{ id: 5, label: '6' },
+						{ id: 6, label: '7' },
+						{ id: 7, label: '8' },
+						{ id: 8, label: '9' },
+						{ id: 9, label: '10' },
+					],
+					default: 0,
+				},
+			],
+			callback: async (event) => {
+				// ideally, one would not use the aes70 object numbers, but the roles ArrayProcessing/ArrayProcessing_Name1 to 40 to be compatible with other amps
+				const startONo = 269521410;			
+				const channelOffset = 32768;
+				const presetOffset = 1048576;
+				try {
+					if (event.options.APspeaker === -1) { // All speakers selected
+						for (let i = 0; i < 4; i++) {
+							const switchID = startONo + event.options.APpreset * presetOffset + i * channelOffset;
+							const fanSwitch = new RemoteControlClasses.OcaSwitch(switchID.toString(), self.remoteDevice);
+							await fanSwitch.SetPosition(1);
+							self.log('info', 'Switch ' + switchID + ' set to ON');
+						}
+					} else { // Individual speaker selected
+						const switchID = startONo + event.options.APpreset * presetOffset + event.options.APspeaker * channelOffset;
+						const fanSwitch = new RemoteControlClasses.OcaSwitch(switchID.toString(), self.remoteDevice);
+						await fanSwitch.SetPosition(1);
+						self.log('info', 'Switch ' + switchID + ' set to ON');
+					}
+				} catch (error) {
+					self.log('error', 'Error setting switch position:', error);
+				}
+				// }
 			},
 		},
 	})

--- a/feedbacks.js
+++ b/feedbacks.js
@@ -35,8 +35,8 @@ export async function updateF(self) {
 			type: 'boolean',
 			label: 'Power Amp',
 			defaultStyle: {
-				bgcolor: combineRgb(255, 0, 0),
-				color: combineRgb(255, 255, 255),
+				bgcolor: combineRgb(0, 255, 0),
+				color: combineRgb(0, 0, 0),
 			},
 			options: [],
 			callback: (feedback) => {

--- a/main.js
+++ b/main.js
@@ -83,13 +83,13 @@ class ModuleInstance extends InstanceBase {
 	setAmpPower(power, type) {
 		let powerType = false;
 		switch(type) {
-			case "5d":
+			case "5D":
 				powerType = power;
 			break;
-			case "d40":
+			case "D40":
 				powerType = !power;
 			break;
-			case "40d":
+			case "40D":
 				powerType = !power;
 			break;
 			default:

--- a/main.js
+++ b/main.js
@@ -26,11 +26,13 @@ class ModuleInstance extends InstanceBase {
 
 	getPowerHourPath(type) {
 		switch (type) {
-			case "5d":
+			case "5D":
 				return "Log_Box/Log_PowerOnHours";
-			case "d40":
+			case "D20":
 				return "Log/Log_PowerOnHours";
-			case "40d":
+			case "D40":
+				return "Log/Log_PowerOnHours";
+			case "40D":
 				return "Log/Log_PowerOnHours";
 			default:
 				return "Log/Log_PowerOnHours";
@@ -39,11 +41,11 @@ class ModuleInstance extends InstanceBase {
 
 	getPowerPath(type) {
 		switch (type) {
-			case "5d":
+			case "5D":
 				return "Settings_Box/Settings_PwrOn";
-			case "d40":
+			case "D40":
 				return "Settings/Settings_PwrOn";
-			case "40d":
+			case "40D":
 				return "Settings/Settings_PwrOn";
 			default:
 				return "Settings/Settings_PwrOn";

--- a/main.js
+++ b/main.js
@@ -52,12 +52,20 @@ class ModuleInstance extends InstanceBase {
 
 	getPortFromType(type) {
 		switch(type) {
-			case "5d":
+			case "5D":
 				return 50014;
-			case "d40":
+			case "10D":
+				return 30013;
+			case "30D":
+				return 30013;
+			case "40D":
 				return 50014;
-			case "40d":
+			case "D20":
+				return 30013;
+			case "D40":
 				return 50014;
+			case "D80":
+				return 30013;
 			case "custom":
 				return this.config.port;
 			default:

--- a/main.js
+++ b/main.js
@@ -20,7 +20,7 @@ class ModuleInstance extends InstanceBase {
 		this.ready = false
 		this.updateActions(InstanceStatus.Connecting)
 		this.updateVariableDefinitions()
-		this.log('info', 'Aes70 Device Connection at port: ' + this.port)
+		this.log('info', 'AES70 Device Connection at port: ' + this.port)
 		this.connect()
 	}
 
@@ -103,14 +103,14 @@ class ModuleInstance extends InstanceBase {
 			port: this.port,
 		})
 			.then((con) => {
-				this.log('info', 'Date: '+ new Date().toISOString()  +' | Aes70 Device Connected');
+				this.log('info', 'Date: '+ new Date().toISOString()  +' | AES70 Device Connected');
 				this.aescon = con
 				this.remoteDevice = new RemoteDevice(con)
 				this.remoteDevice.set_keepalive_interval(1)
 				this.remoteDevice.on("close", (args)=> {
-					this.log('warn', 'Date: '+ new Date().toISOString()  +' | Aes70 Device Connection closed!')
+					this.log('warn', 'Date: '+ new Date().toISOString()  +' | AES70 Device Connection closed!')
 					this.ready = false
-					this.log('warn', 'Date: '+ new Date().toISOString()  +' | Aes70 Device Connection Error try reconnect in 10 Seconds!')
+					this.log('warn', 'Date: '+ new Date().toISOString()  +' | AES70 Device Connection Error try reconnect in 10 Seconds!')
 					this.updateStatus(InstanceStatus.ConnectionFailure)
 					setTimeout(() => {
 						this.updateStatus(InstanceStatus.Connecting)
@@ -120,10 +120,10 @@ class ModuleInstance extends InstanceBase {
 				})
 
 				this.remoteDevice.on("error", (args)=> {
-					this.log('warn', 'Date: '+ new Date().toISOString() +' | Aes70 Device Connection closed with Error!')
+					this.log('warn', 'Date: '+ new Date().toISOString() +' | AES70 Device Connection closed with Error!')
 					this.log('error', JSON.stringify(args))
 					this.ready = false
-					this.log('warn', 'Date: '+ new Date().toISOString()  +' | Aes70 Device Connection Error try reconnect in 10 Seconds!')
+					this.log('warn', 'Date: '+ new Date().toISOString()  +' | AES70 Device Connection Error try reconnect in 10 Seconds!')
 					setTimeout(() => {
 						this.updateStatus(InstanceStatus.UnknownError, JSON.stringify(args)	);
 						this.destroy()
@@ -213,7 +213,7 @@ class ModuleInstance extends InstanceBase {
 			})
 			.catch((e) => {
 				this.ready = false
-				this.log('warn', 'Date: '+ new Date().toISOString()  +' | Aes70 Device Connection Error try reconnect in 10 Seconds!')
+				this.log('warn', 'Date: '+ new Date().toISOString()  +' | AES70 Device Connection Error try reconnect in 10 Seconds!')
 				setTimeout(() => {
 					this.connect()
 					this.updateStatus(InstanceStatus.UnknownError, JSON.stringify(e)	);

--- a/main.js
+++ b/main.js
@@ -107,6 +107,10 @@ class ModuleInstance extends InstanceBase {
 		this.setVariableValues({[varindex]: mute})
 	}
 
+	setAmpAPpreset(APpreset){
+		// ap preset variables and feedback should get set here
+	}
+
 	connect() {
 		TCPConnection.connect({
 			host: this.config.host,


### PR DESCRIPTION
- added ports for 10D, 30D, D20 and D80 amps (everything tested with D20, D80 and D40 amps)
- added the ability to select array processing presets on D20 amps for individual or all speakers
- changed power state feedback to reflect the colors shown on the amps
- changed actions to be toggle by default
- fixed spelling of actions